### PR TITLE
feat: standalone availability callout section (closes #16)

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -55,15 +55,12 @@
         </div>
 
         <!-- Working style callout -->
-        <div class="mt-7 pl-5 border-l-2 border-forest/30 space-y-4">
+        <div class="mt-7 pl-5 border-l-2 border-forest/30">
           <p class="text-sm leading-relaxed text-gray-500">
             I work best asynchronously and have been called a "secret PM" by
             clients for how I organize and run projects. Every engagement runs
             through Basecamp with clear timelines, regular updates, and zero
             chasing.
-          </p>
-          <p class="text-sm leading-relaxed text-gray-500">
-            <strong class="text-gray-600 font-medium">A note on availability:</strong> I operate during regular business hours (Mon–Fri, 9am–6pm PT) and pride myself on fast, proactive communication — but I'm not a 24/7 agency. If your business needs round-the-clock support or weekend coverage, we're probably not the right fit. If you want a responsive, organized partner who treats your project like it matters, let's talk.
           </p>
         </div>
 

--- a/src/components/Availability.astro
+++ b/src/components/Availability.astro
@@ -1,0 +1,102 @@
+---
+---
+
+<section class="bg-cream">
+  <div class="max-w-site mx-auto px-6 md:px-12 py-16 md:py-20">
+
+    <div
+      class="mb-10"
+      data-sal="fade-up"
+      data-sal-duration="500"
+    >
+      <p class="text-[13px] font-semibold text-forest tracking-wide mb-3">How I work</p>
+      <h2 class="font-serif text-3xl md:text-[40px] leading-[1.15]">
+        A few honest things.
+      </h2>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+
+      <!-- What to expect -->
+      <div
+        class="bg-white border border-gray-200 rounded-2xl p-8"
+        data-sal="fade-up"
+        data-sal-duration="500"
+        data-sal-delay="100"
+      >
+        <div class="w-8 h-8 rounded-full bg-forest-pale flex items-center justify-center mb-5">
+          <svg class="w-4 h-4 text-forest" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+        <h3 class="font-serif text-xl mb-4">What working with me looks like</h3>
+        <ul class="space-y-3 text-[15px] leading-[1.7] text-gray-600">
+          <li class="flex items-start gap-3">
+            <span class="text-forest mt-1 flex-shrink-0">
+              <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 12 12"><circle cx="6" cy="6" r="2.5"/></svg>
+            </span>
+            I operate during regular business hours — Mon–Fri, 9am–4pm PT.
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="text-forest mt-1 flex-shrink-0">
+              <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 12 12"><circle cx="6" cy="6" r="2.5"/></svg>
+            </span>
+            Fast, proactive communication. You'll always know where things stand — I'm the one chasing updates, not you.
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="text-forest mt-1 flex-shrink-0">
+              <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 12 12"><circle cx="6" cy="6" r="2.5"/></svg>
+            </span>
+            Every project runs through Basecamp with clear timelines and structured async communication.
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="text-forest mt-1 flex-shrink-0">
+              <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 12 12"><circle cx="6" cy="6" r="2.5"/></svg>
+            </span>
+            If something goes down, we show up. Urgency is real — we get it.
+          </li>
+        </ul>
+      </div>
+
+      <!-- Not the right fit -->
+      <div
+        class="bg-white border border-gray-200 rounded-2xl p-8"
+        data-sal="fade-up"
+        data-sal-duration="500"
+        data-sal-delay="200"
+      >
+        <div class="w-8 h-8 rounded-full bg-gray-100 flex items-center justify-center mb-5">
+          <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </div>
+        <h3 class="font-serif text-xl mb-4">Probably not the right fit if&hellip;</h3>
+        <ul class="space-y-3 text-[15px] leading-[1.7] text-gray-600">
+          <li class="flex items-start gap-3">
+            <span class="text-gray-300 mt-1 flex-shrink-0">
+              <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 12 12"><circle cx="6" cy="6" r="2.5"/></svg>
+            </span>
+            Your business needs round-the-clock support or weekend coverage.
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="text-gray-300 mt-1 flex-shrink-0">
+              <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 12 12"><circle cx="6" cy="6" r="2.5"/></svg>
+            </span>
+            You want to add me to your Slack or expect replies to text messages.
+          </li>
+          <li class="flex items-start gap-3">
+            <span class="text-gray-300 mt-1 flex-shrink-0">
+              <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 12 12"><circle cx="6" cy="6" r="2.5"/></svg>
+            </span>
+            You need a large agency team on-call at all hours.
+          </li>
+        </ul>
+
+        <p class="mt-6 text-sm text-gray-400 leading-relaxed">
+          I have a family. I build boundaries intentionally — and it's part of why the work I do deliver is focused and high quality.
+        </p>
+      </div>
+
+    </div>
+  </div>
+</section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,6 +8,7 @@ import Services from '../components/Services.astro';
 import Work from '../components/Work.astro';
 import ProcessTimeline from '../components/ProcessTimeline.astro';
 import FewerClients from '../components/FewerClients.astro';
+import Availability from '../components/Availability.astro';
 import About from '../components/About.astro';
 import Testimonials from '../components/Testimonials.astro';
 import FooterCTA from '../components/FooterCTA.astro';
@@ -25,6 +26,7 @@ import '../styles/global.css';
     <Work />
     <ProcessTimeline />
     <FewerClients />
+    <Availability />
     <About />
     <Testimonials />
     <FooterCTA />


### PR DESCRIPTION
- New Availability.astro component placed between FewerClients and About
- Two-card layout: "What working with me looks like" + "Probably not the right fit if..."
- Updated copy: family mention, 9am-4pm PT, no Slack/texts, emergency caveat
- Removed buried availability paragraph from About.astro

## Summary

- **Closes #16**
- Moved the availability callout out of the About section and into a dedicated `Availability.astro` component
- Placed between FewerClients and About — thematically flows from "we're selective" into "here's what that looks like in practice"
- Two-card layout: positive expectations on the left, self-selection criteria on the right
- Updated copy: family context, 9am–4pm PT hours, no Slack/texts, emergency caveat included
- Removed the buried paragraph from About.astro
