### PR TITLE
feat: add AI service card, surface design skills, and sharpen operator copy

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -40,8 +40,8 @@
           <p>
             That experience rewired how I think about development. When I look at
             your store, I'm not just thinking about clean code — I'm thinking
-            about what's going to move your conversion rate, increase your AOV,
-            and keep customers coming back. I've been on your side of the P&L. I
+            about what's going to move your conversion rate, improve your
+            contribution margin, and keep customers coming back. I've been on your side of the P&L. I
             know what it costs when something is built wrong, and what it's worth
             when it's built right.
           </p>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -53,8 +53,8 @@ const bookingMonth = bookingDate.toLocaleString('en-US', { month: 'long', year: 
       data-sal-duration="500"
       data-sal-delay="300"
     >
-      The difference? I run my own ecommerce brand on Shopify. I track the same
-      metrics you do — revenue, LTV, AOV — and I bring that operator perspective
+      The difference? I run my own bootstrapped ecommerce brand on Shopify. I track the same
+      metrics you do — contribution margin, LTV, CAC — and I bring that operator perspective
       to every project. Your store deserves more than just code. It deserves
       someone who understands the business behind it.
     </p>

--- a/src/components/Services.astro
+++ b/src/components/Services.astro
@@ -4,20 +4,27 @@ const services = [
     title: 'Custom Theme Development',
     body: 'Full builds and redesigns on Shopify and Shopify Plus. Clean, performant Liquid code built to last and easy to maintain long after launch.',
     startingAt: '$5,000',
+    pricingNote: 'For a simple 5-page build with design in hand. Typical full build: $15–20k.',
   },
   {
     title: 'CRO-Focused UI/UX',
-    body: "Conversion-focused design and UX improvements backed by more than a decade of UI/UX experience and an operator's understanding of what actually moves customers to buy.",
+    body: "Conversion-focused UX improvements worked in Figma and in code — improving and extending your existing brand rather than rebuilding from scratch. From page-level redesigns to component-level CRO, backed by more than a decade of UI/UX experience and an operator's eye for what actually moves customers to buy.",
   },
   {
     title: 'Ecommerce Strategy & Consulting',
-    body: "High-level thinking on your store architecture, app stack, and growth levers. Not just what to build — what to build first and why it matters for your bottom line.",
+    body: "Strategy backed by real skin in the game: we've grown our own bootstrapped brand from $0 to six figures on Shopify. High-level thinking on your architecture, app stack, and growth levers — thinking in contribution margin and CAC payback, not just top-line revenue. Not just what to build, but what to build first and why it matters for your bottom line.",
   },
   {
     title: 'Ongoing Retainers',
     body: 'We do our best work with brands we know deeply. Retainer partnerships let us stay embedded in your business and ship improvements continuously.',
     startingAt: '$2,000',
-    fomo: true,
+    badge: '2/3 spots filled',
+  },
+  {
+    title: 'AI for Your Business',
+    body: "AI isn't just how we build — it's something we bring directly into your business. Whether that means teaching your team to work faster with AI tools, building custom Claude skills and plugins that automate your workflows, or adding AI-native features to your store, we help you get real leverage from it. Platform-agnostic: we lead with Claude but work with whatever fits your stack. Faster development timelines come with the territory — this studio's own site was built entirely with AI-assisted tools.",
+    badge: 'New',
+    wide: true,
   },
 ];
 ---
@@ -43,22 +50,30 @@ const services = [
     <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
       {services.map((service, i) => (
         <div
-          class="border border-gray-200 border-t-2 border-t-forest rounded-xl p-7 bg-white relative overflow-hidden"
+          class:list={[
+            'border border-gray-200 border-t-2 border-t-forest rounded-xl p-7 bg-white relative overflow-hidden',
+            service.wide && 'md:col-span-2',
+          ]}
           data-sal="fade-up"
           data-sal-duration="500"
           data-sal-delay={String(i * 100)}
         >
-          {service.fomo && (
+          {service.badge && (
             <div class="mb-3">
               <span class="inline-flex items-center gap-1.5 text-xs font-semibold bg-forest-pale text-forest border border-forest/20 rounded-full px-3 py-1">
-                2/3 spots filled
+                {service.badge}
               </span>
             </div>
           )}
           <h3 class="text-base font-bold mb-2">{service.title}</h3>
           <p class="text-sm leading-relaxed text-gray-600">{service.body}</p>
           {service.startingAt && (
-            <p class="text-sm font-medium text-forest mt-3">Starting at {service.startingAt}</p>
+            <div class="mt-3">
+              <p class="text-sm font-medium text-forest">Starting at {service.startingAt}</p>
+              {service.pricingNote && (
+                <p class="text-xs text-gray-400 mt-0.5">{service.pricingNote}</p>
+              )}
+            </div>
           )}
         </div>
       ))}

--- a/src/components/ValueProp.astro
+++ b/src/components/ValueProp.astro
@@ -10,7 +10,7 @@
   >
     <p class="font-serif text-2xl md:text-[26px] leading-snug md:leading-[1.5] text-charcoal max-w-3xl">
       Pixel-perfect implementation, customer experience improvements, and custom
-      on-brand features — built by a team that tracks the same metrics you do.
+      on-brand features — built by a team that reads the same P&L you do.
     </p>
   </div>
 </section>


### PR DESCRIPTION
## Summary

- **Issue #21** — Adds "AI for Your Business" as a 5th full-width service card. Copy leads with customer value (Claude skills/plugins, workflow automation, AI-native store features), platform-agnostic positioning, with faster dev timelines as secondary. Refactored `fomo` → `badge` string field so badge text is consistent across cards ("2/3 spots filled" / "New").
- **Issue #23** — Updated "CRO-Focused UI/UX" card copy to surface design capabilities without marketing standalone design work. Framed as: Figma + in-code, extending existing brands, backed by 10+ years of UI/UX experience.
- **Issue #31** — Upgraded operator-language copy across four components:
  - **Hero**: "bootstrapped ecommerce brand" + `contribution margin, LTV, CAC`
  - **About**: `improve your contribution margin` + "I've been on your side of the P&L"
  - **Services (Ecommerce Strategy)**: "thinking in contribution margin and CAC payback, not just top-line revenue"
  - **ValueProp**: "reads the same P&L you do"
- **Pricing context** — Added `pricingNote` field to Custom Theme Development card: "For a simple 5-page build with design in hand. Typical full build: $15–20k."
- **Ecommerce Strategy copy** — Added "grown our own bootstrapped brand from $0 to six figures on Shopify" as the lead credibility sentence.

## Files changed
- `src/components/Services.astro`
- `src/components/Hero.astro`
- `src/components/About.astro`
- `src/components/ValueProp.astro`

## Test plan
- [x] Clean build, no errors
- [x] Desktop: 2×2 service grid + full-width AI card
- [x] Mobile: single-column, AI card full width
- [x] Badges render on Ongoing Retainers and AI card
- [x] Pricing note renders below starting price on Custom Theme Development
- [x] Operator language verified in DOM across all four components

🤖 Generated with [Claude Code](https://claude.com/claude-code)
