### PR TITLE
feat: contact form improvements — project type, scope, timeframe, and pricing context (closes #15)

### DIFF
--- a/src/components/Services.astro
+++ b/src/components/Services.astro
@@ -4,7 +4,10 @@ const services = [
     title: 'Custom Theme Development',
     body: 'Full builds and redesigns on Shopify and Shopify Plus. Clean, performant Liquid code built to last and easy to maintain long after launch.',
     startingAt: '$5,000',
-    pricingNote: 'For a simple 5-page build with design in hand. Typical full build: $15–20k.',
+    pricingNotes: [
+      'For a simple 5-page build with design in hand.',
+      'Typical full build: $15–30k.',
+    ],
   },
   {
     title: 'CRO-Focused UI/UX',
@@ -70,8 +73,12 @@ const services = [
           {service.startingAt && (
             <div class="mt-3">
               <p class="text-sm font-medium text-forest">Starting at {service.startingAt}</p>
-              {service.pricingNote && (
-                <p class="text-xs text-gray-400 mt-0.5">{service.pricingNote}</p>
+              {service.pricingNotes && (
+                <div class="mt-1 space-y-1">
+                  {service.pricingNotes.map(note => (
+                    <p class="text-xs text-gray-400">{note}</p>
+                  ))}
+                </div>
               )}
             </div>
           )}

--- a/src/components/Services.astro
+++ b/src/components/Services.astro
@@ -4,8 +4,8 @@ const services = [
     title: 'Custom Theme Development',
     body: 'Full builds and redesigns on Shopify and Shopify Plus. Clean, performant Liquid code built to last and easy to maintain long after launch.',
     startingAt: '$5,000',
+    startingAtNote: 'for a simple 5-page build with design in hand.',
     pricingNotes: [
-      'For a simple 5-page build with design in hand.',
       'Typical full build: $15–30k.',
     ],
   },
@@ -72,7 +72,9 @@ const services = [
           <p class="text-sm leading-relaxed text-gray-600">{service.body}</p>
           {service.startingAt && (
             <div class="mt-3">
-              <p class="text-sm font-medium text-forest">Starting at {service.startingAt}</p>
+              <p class="text-sm font-medium text-forest">
+                Starting at {service.startingAt}{service.startingAtNote && <span class="font-normal text-gray-400"> — {service.startingAtNote}</span>}
+              </p>
               {service.pricingNotes && (
                 <div class="mt-1 space-y-1">
                   {service.pricingNotes.map(note => (

--- a/src/pages/contact/index.astro
+++ b/src/pages/contact/index.astro
@@ -27,9 +27,8 @@ const description = 'Get in touch about your Shopify project. Custom development
           data-sal-duration="500"
           data-sal-delay="100"
         >
-          Fill out the form below with some details about your project. It helps
-          to include your Shopify URL, budget range, goals, and target timeframe.
-          I'll get back to you within one business day.
+          Fill out the form below with some details about your project. I'll get
+          back to you within one business day.
         </p>
 
         <form
@@ -48,6 +47,9 @@ const description = 'Get in touch about your Shopify project. Custom development
         >
           <!-- Required for Netlify to identify the form on JS-submitted POSTs -->
           <input type="hidden" name="form-name" value="contact" />
+          <!-- Hidden inputs for project type and scope -->
+          <input type="hidden" name="project_type" x-bind:value="projectType" />
+          <input type="hidden" name="scope" x-bind:value="scope" />
           <!-- Honeypot for spam -->
           <p class="hidden">
             <label>Don't fill this out: <input name="bot-field" /></label>
@@ -89,6 +91,58 @@ const description = 'Get in touch about your Shopify project. Custom development
             </div>
           </div>
 
+          <!-- Project Type -->
+          <div>
+            <label class="block text-sm font-medium text-charcoal mb-2">Project Type</label>
+            <div class="grid grid-cols-2 gap-3">
+              <button
+                type="button"
+                @click="projectType = 'one-off'; scope = ''"
+                :class="projectType === 'one-off' ? 'border-forest bg-forest text-white' : 'border-gray-200 bg-white text-gray-600 hover:border-gray-300'"
+                class="px-4 py-3 rounded-lg border text-sm font-medium transition-colors text-left"
+              >
+                One-off project
+              </button>
+              <button
+                type="button"
+                @click="projectType = 'retainer'; scope = ''"
+                :class="projectType === 'retainer' ? 'border-forest bg-forest text-white' : 'border-gray-200 bg-white text-gray-600 hover:border-gray-300'"
+                class="px-4 py-3 rounded-lg border text-sm font-medium transition-colors text-left"
+              >
+                Ongoing retainer
+              </button>
+            </div>
+          </div>
+
+          <!-- Scope (one-off only) -->
+          <div x-show="projectType === 'one-off'" x-transition style="display:none">
+            <label class="block text-sm font-medium text-charcoal mb-2">Scope</label>
+            <div class="grid grid-cols-2 gap-3">
+              <button
+                type="button"
+                @click="scope = 'fresh-build'"
+                :class="scope === 'fresh-build' ? 'border-forest bg-forest text-white' : 'border-gray-200 bg-white text-gray-600 hover:border-gray-300'"
+                class="px-4 py-3 rounded-lg border text-sm font-medium transition-colors text-left"
+              >
+                Fresh build
+              </button>
+              <button
+                type="button"
+                @click="scope = 'maintenance'"
+                :class="scope === 'maintenance' ? 'border-forest bg-forest text-white' : 'border-gray-200 bg-white text-gray-600 hover:border-gray-300'"
+                class="px-4 py-3 rounded-lg border text-sm font-medium transition-colors text-left"
+              >
+                Maintenance & improvements
+              </button>
+            </div>
+            <p
+              x-show="scope"
+              x-text="scope === 'fresh-build' ? 'Fresh builds start at $5,000.' : 'Maintenance projects start at $1,000.'"
+              class="text-xs text-gray-400 mt-2"
+              style="display:none"
+            ></p>
+          </div>
+
           <div>
             <label for="shopify-url" class="block text-sm font-medium text-charcoal mb-2">
               Shopify Store URL <span class="text-gray-400 font-normal">(if applicable)</span>
@@ -118,6 +172,23 @@ const description = 'Get in touch about your Shopify project. Custom development
               <option value="20k-plus">$20,000+</option>
               <option value="retainer">Ongoing retainer</option>
               <option value="not-sure">Not sure yet</option>
+            </select>
+          </div>
+
+          <div>
+            <label for="timeframe" class="block text-sm font-medium text-charcoal mb-2">
+              Target Timeframe <span class="text-gray-400 font-normal">(optional)</span>
+            </label>
+            <select
+              id="timeframe"
+              name="timeframe"
+              class="w-full px-4 py-3 rounded-lg border border-gray-300 bg-white text-charcoal text-sm focus:outline-none focus:ring-2 focus:ring-forest/20 focus:border-forest transition-colors"
+            >
+              <option value="" selected>Not sure yet</option>
+              <option value="asap">ASAP</option>
+              <option value="1-2-months">1–2 months</option>
+              <option value="3-6-months">3–6 months</option>
+              <option value="flexible">Flexible</option>
             </select>
           </div>
 
@@ -158,6 +229,8 @@ const description = 'Get in touch about your Shopify project. Custom development
     name: '',
     email: '',
     message: '',
+    projectType: '',
+    scope: '',
     errors: {} as Record<string, string>,
 
     validate() {

--- a/src/pages/contact/index.astro
+++ b/src/pages/contact/index.astro
@@ -94,7 +94,7 @@ const description = 'Get in touch about your Shopify project. Custom development
           <!-- Project Type -->
           <div>
             <label class="block text-sm font-medium text-charcoal mb-2">Project Type</label>
-            <div class="grid grid-cols-2 gap-3">
+            <div class="grid grid-cols-3 gap-3">
               <button
                 type="button"
                 @click="projectType = 'one-off'; scope = ''"
@@ -110,6 +110,14 @@ const description = 'Get in touch about your Shopify project. Custom development
                 class="px-4 py-3 rounded-lg border text-sm font-medium transition-colors text-left"
               >
                 Ongoing retainer
+              </button>
+              <button
+                type="button"
+                @click="projectType = 'other'; scope = ''"
+                :class="projectType === 'other' ? 'border-forest bg-forest text-white' : 'border-gray-200 bg-white text-gray-600 hover:border-gray-300'"
+                class="px-4 py-3 rounded-lg border text-sm font-medium transition-colors text-left"
+              >
+                Other
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary

### Contact form (`src/pages/contact/index.astro`)
- **Project Type** toggle: One-off project / Ongoing retainer / Other
- **Scope** toggle (conditionally shown for One-off only): Fresh build / Maintenance & improvements
- **Inline pricing note** appears when scope is selected — "Fresh builds start at $5,000." / "Maintenance projects start at $1,000."
- **Target Timeframe** select field (optional): ASAP, 1–2 months, 3–6 months, Flexible
- `project_type` and `scope` submitted as hidden inputs so values appear in Netlify form submissions

### Services card (`src/components/Services.astro`)
- Updated Custom Theme Development pricing context to `$15–30k` typical full build
- Moved "for a simple 5-page build with design in hand." inline on the Starting at line
- "Typical full build: $15–30k." rendered as its own separate line below

## Files changed
- `src/pages/contact/index.astro`
- `src/components/Services.astro`

## Test plan
- [x] All three project type buttons toggle active state correctly
- [x] Scope section appears only when One-off is selected
- [x] Pricing note updates correctly based on scope selection
- [x] Other and Ongoing retainer selections hide scope section
- [x] Timeframe field renders between Budget and Project Details
- [x] Pricing context on Custom Theme card reads correctly in two lines
- [x] Form validates and submits correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
