### PR TITLE
polish: animation improvements from Emil Kowalski design review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,10 @@ This is a 1-person project. Loosely follow git flow:
 
 **Run `/simplify` before pushing for PR review** — Always run `/simplify` on the changed files before pushing a branch up for PR review. It catches duplicate logic, redundant state, stale comments, and efficiency issues before they show up in bot review findings.
 
+**`inert` required on CSS-animated collapsibles** — Animating visibility via `grid-template-rows: 0fr` (or `max-height`, `clip-path`, etc.) does not remove content from the tab order. `aria-hidden="true"` hides content from the accessibility tree but does not prevent keyboard focus. Always add the `inert` boolean attribute to the closed state and toggle it in open/close handlers (`removeAttribute('inert')` / `setAttribute('inert', '')`).
+
+_Last updated: 2026-04-21_
+
 ## Key Files
 
 - `src/components/` — all page sections as Astro components

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -74,9 +74,9 @@
       } else {
         // Start hidden + blurred; reveal on scroll entry
         wordmark.style.opacity    = '0';
-        wordmark.style.filter     = 'blur(20px)';
+        wordmark.style.filter     = 'blur(12px)';
         wordmark.style.transition =
-          'opacity 1.4s cubic-bezier(0.16, 1, 0.3, 1), filter 1.4s cubic-bezier(0.16, 1, 0.3, 1)';
+          'opacity 0.9s cubic-bezier(0.16, 1, 0.3, 1), filter 0.9s cubic-bezier(0.16, 1, 0.3, 1)';
 
         const revealObserver = new IntersectionObserver(
           (entries) => {

--- a/src/components/FooterCTA.astro
+++ b/src/components/FooterCTA.astro
@@ -17,7 +17,7 @@
       </p>
       <a
         href="/contact"
-        class="group inline-block px-8 py-3.5 bg-cream text-forest rounded-lg text-[15px] font-semibold hover:bg-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cream focus-visible:ring-offset-2 focus-visible:ring-offset-forest"
+        class="group btn inline-block px-8 py-3.5 bg-cream text-forest rounded-lg text-[15px] font-semibold hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cream focus-visible:ring-offset-2 focus-visible:ring-offset-forest"
       >
         Get in Touch <span class="inline-block transition-transform duration-200 ease-out group-hover:translate-x-1">→</span>
       </a>

--- a/src/components/FooterCTA.astro
+++ b/src/components/FooterCTA.astro
@@ -19,8 +19,19 @@
         href="/contact"
         class="group btn inline-block px-8 py-3.5 bg-cream text-forest rounded-lg text-[15px] font-semibold hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cream focus-visible:ring-offset-2 focus-visible:ring-offset-forest"
       >
-        Get in Touch <span class="inline-block transition-transform duration-200 ease-out group-hover:translate-x-1">→</span>
+        Get in Touch <span class="footer-arrow inline-block">→</span>
       </a>
     </div>
   </div>
 </section>
+
+<style>
+  .footer-arrow {
+    transition: transform 200ms cubic-bezier(0.23, 1, 0.32, 1);
+  }
+  @media (hover: hover) and (pointer: fine) {
+    .group:hover .footer-arrow {
+      transform: translateX(4px);
+    }
+  }
+</style>

--- a/src/components/FooterCTA.astro
+++ b/src/components/FooterCTA.astro
@@ -19,19 +19,9 @@
         href="/contact"
         class="group btn inline-block px-8 py-3.5 bg-cream text-forest rounded-lg text-[15px] font-semibold hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cream focus-visible:ring-offset-2 focus-visible:ring-offset-forest"
       >
-        Get in Touch <span class="footer-arrow inline-block">→</span>
+        Get in Touch <span class="btn-arrow">→</span>
       </a>
     </div>
   </div>
 </section>
 
-<style>
-  .footer-arrow {
-    transition: transform 200ms cubic-bezier(0.23, 1, 0.32, 1);
-  }
-  @media (hover: hover) and (pointer: fine) {
-    .group:hover .footer-arrow {
-      transform: translateX(4px);
-    }
-  }
-</style>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -68,13 +68,13 @@ const bookingMonth = bookingDate.toLocaleString('en-US', { month: 'long', year: 
     >
       <a
         href="/contact"
-        class="group inline-block px-8 py-3.5 bg-forest text-white rounded-lg text-[15px] font-semibold hover:bg-forest-light transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-forest focus-visible:ring-offset-2"
+        class="group btn inline-block px-8 py-3.5 bg-forest text-white rounded-lg text-[15px] font-semibold hover:bg-forest-light focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-forest focus-visible:ring-offset-2"
       >
         Start a Project <span class="inline-block transition-transform duration-200 ease-out group-hover:translate-x-1">→</span>
       </a>
       <a
         href="#work"
-        class="inline-block px-8 py-3.5 border-[1.5px] border-ui-border-md text-charcoal rounded-lg text-[15px] font-semibold hover:border-ui-faint transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-charcoal/40 focus-visible:ring-offset-2"
+        class="btn inline-block px-8 py-3.5 border-[1.5px] border-ui-border-md text-charcoal rounded-lg text-[15px] font-semibold hover:border-ui-faint focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-charcoal/40 focus-visible:ring-offset-2"
       >
         See Our Work
       </a>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -129,7 +129,7 @@ const bookingMonth = bookingDate.toLocaleString('en-US', { month: 'long', year: 
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
 
     const EASING = 'cubic-bezier(0.16, 1, 0.3, 1)'; // ease-out-quart
-    const WORD_DURATION = 780;
+    const WORD_DURATION = 600;
     const WORD_STAGGER = 52;
     const WORD_START_DELAY = 100; // slight offset after badge/eyebrow sal entrance
 

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -70,7 +70,7 @@ const bookingMonth = bookingDate.toLocaleString('en-US', { month: 'long', year: 
         href="/contact"
         class="group btn inline-block px-8 py-3.5 bg-forest text-white rounded-lg text-[15px] font-semibold hover:bg-forest-light focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-forest focus-visible:ring-offset-2"
       >
-        Start a Project <span class="btn-arrow inline-block">→</span>
+        Start a Project <span class="btn-arrow">→</span>
       </a>
       <a
         href="#work"
@@ -88,16 +88,6 @@ const bookingMonth = bookingDate.toLocaleString('en-US', { month: 'long', year: 
        ::before — dot grid (forest green, 24px pitch, 1px dots at 9% opacity)
        ::after  — fractal noise grain (neutral, ~6% opacity) for tactile depth
      Content sits at z-10 above both.                                         */
-
-  /* Arrow nudge — hover-only devices only */
-  @media (hover: hover) and (pointer: fine) {
-    .group:hover .btn-arrow {
-      transform: translateX(4px);
-    }
-  }
-  .btn-arrow {
-    transition: transform 200ms cubic-bezier(0.23, 1, 0.32, 1);
-  }
 
   #hero::before {
     content: '';

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -70,7 +70,7 @@ const bookingMonth = bookingDate.toLocaleString('en-US', { month: 'long', year: 
         href="/contact"
         class="group btn inline-block px-8 py-3.5 bg-forest text-white rounded-lg text-[15px] font-semibold hover:bg-forest-light focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-forest focus-visible:ring-offset-2"
       >
-        Start a Project <span class="inline-block transition-transform duration-200 ease-out group-hover:translate-x-1">→</span>
+        Start a Project <span class="btn-arrow inline-block">→</span>
       </a>
       <a
         href="#work"
@@ -88,6 +88,16 @@ const bookingMonth = bookingDate.toLocaleString('en-US', { month: 'long', year: 
        ::before — dot grid (forest green, 24px pitch, 1px dots at 9% opacity)
        ::after  — fractal noise grain (neutral, ~6% opacity) for tactile depth
      Content sits at z-10 above both.                                         */
+
+  /* Arrow nudge — hover-only devices only */
+  @media (hover: hover) and (pointer: fine) {
+    .group:hover .btn-arrow {
+      transform: translateX(4px);
+    }
+  }
+  .btn-arrow {
+    transition: transform 200ms cubic-bezier(0.23, 1, 0.32, 1);
+  }
 
   #hero::before {
     content: '';

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -12,7 +12,7 @@ const bookingMonth = bookingDate.toLocaleString('en-US', { month: 'long', year: 
       data-sal-duration="500"
     >
       <span class="inline-flex items-center gap-2 bg-forest-pale text-forest text-[12px] font-semibold tracking-wide px-3.5 py-1.5 rounded-full border border-forest/20">
-        <span class="w-1.5 h-1.5 rounded-full bg-forest animate-pulse inline-block flex-shrink-0"></span>
+        <span class="w-1.5 h-1.5 rounded-full bg-forest inline-block flex-shrink-0"></span>
         Now Booking {bookingMonth}
       </span>
     </div>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -64,7 +64,7 @@ const bookingMonth = bookingDate.toLocaleString('en-US', { month: 'long', year: 
       class="flex flex-wrap gap-4"
       data-sal="fade-up"
       data-sal-duration="500"
-      data-sal-delay="400"
+      data-sal-delay="280"
     >
       <a
         href="/contact"

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -9,7 +9,7 @@ const navLinks = [
 
 <nav class="sticky top-0 z-50 bg-white border-b border-ui-border">
   <div class="max-w-site mx-auto px-6 md:px-12 py-4 flex items-center justify-between">
-    <a href="/" class="font-serif text-[22px] tracking-[-0.06em] text-forest hover:text-charcoal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-forest focus-visible:ring-offset-1 rounded-sm" style="transition: color 150ms cubic-bezier(0.23, 1, 0.32, 1)">
+    <a href="/" class="color-transition font-serif text-[22px] tracking-[-0.06em] text-forest hover:text-charcoal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-forest focus-visible:ring-offset-1 rounded-sm">
       Lindahl Studios
     </a>
 
@@ -53,7 +53,7 @@ const navLinks = [
       {navLinks.map((link) => (
         <a
           href={link.href}
-          class="block text-base font-medium text-ui-body hover:text-charcoal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-forest focus-visible:ring-offset-1 rounded-sm" style="transition: color 150ms cubic-bezier(0.23, 1, 0.32, 1)"
+          class="color-transition block text-base font-medium text-ui-body hover:text-charcoal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-forest focus-visible:ring-offset-1 rounded-sm"
         >
           {link.label}
         </a>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -44,9 +44,9 @@ const navLinks = [
     </button>
   </div>
 
-  <!-- Mobile menu -->
-  <div id="mobile-menu" class="hidden md:hidden border-t border-ui-border bg-white">
-    <div class="px-6 py-6 space-y-4">
+  <!-- Mobile menu — animated via grid-rows trick (no height: auto limitation) -->
+  <div id="mobile-menu" class="md:hidden border-t border-ui-border bg-white grid transition-[grid-template-rows] duration-[220ms] ease-[cubic-bezier(0.23,1,0.32,1)] grid-rows-[0fr] overflow-hidden" aria-hidden="true">
+    <div class="px-6 py-6 space-y-4 min-h-0">
       {navLinks.map((link) => (
         <a
           href={link.href}
@@ -66,27 +66,30 @@ const navLinks = [
 </nav>
 
 <script>
-  const btn = document.getElementById('mobile-menu-btn');
-  const menu = document.getElementById('mobile-menu');
+  const btn  = document.getElementById('mobile-menu-btn');
+  const menu = document.getElementById('mobile-menu') as HTMLElement | null;
   const icon = document.getElementById('menu-icon');
 
+  function openMenu() {
+    menu?.classList.replace('grid-rows-[0fr]', 'grid-rows-[1fr]');
+    menu?.setAttribute('aria-hidden', 'false');
+    btn?.setAttribute('aria-expanded', 'true');
+    icon?.setAttribute('d', 'M6 18L18 6M6 6l12 12');
+  }
+
+  function closeMenu() {
+    menu?.classList.replace('grid-rows-[1fr]', 'grid-rows-[0fr]');
+    menu?.setAttribute('aria-hidden', 'true');
+    btn?.setAttribute('aria-expanded', 'false');
+    icon?.setAttribute('d', 'M4 6h16M4 12h16M4 18h16');
+  }
+
   btn?.addEventListener('click', () => {
-    const isOpen = !menu?.classList.contains('hidden');
-    menu?.classList.toggle('hidden');
-    btn?.setAttribute('aria-expanded', String(!isOpen));
-    if (isOpen) {
-      icon?.setAttribute('d', 'M4 6h16M4 12h16M4 18h16');
-    } else {
-      icon?.setAttribute('d', 'M6 18L18 6M6 6l12 12');
-    }
+    menu?.classList.contains('grid-rows-[1fr]') ? closeMenu() : openMenu();
   });
 
   // Close on anchor click (mobile)
   document.querySelectorAll('#mobile-menu a').forEach((link) => {
-    link.addEventListener('click', () => {
-      menu?.classList.add('hidden');
-      btn?.setAttribute('aria-expanded', 'false');
-      icon?.setAttribute('d', 'M4 6h16M4 12h16M4 18h16');
-    });
+    link.addEventListener('click', closeMenu);
   });
 </script>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -47,7 +47,7 @@ const navLinks = [
   <!-- Mobile menu — animated via grid-rows trick (no height: auto limitation).
        Two-level structure is required: grid item must have min-h-0 and NO padding,
        otherwise the padding prevents the track from collapsing to 0fr. -->
-  <div id="mobile-menu" class="md:hidden border-t border-ui-border bg-white grid transition-[grid-template-rows] duration-[220ms] ease-[cubic-bezier(0.23,1,0.32,1)] grid-rows-[0fr] overflow-hidden" aria-hidden="true">
+  <div id="mobile-menu" class="md:hidden border-t border-ui-border bg-white grid transition-[grid-template-rows] duration-[220ms] ease-[cubic-bezier(0.23,1,0.32,1)] grid-rows-[0fr] overflow-hidden" aria-hidden="true" inert>
     <div class="min-h-0">
     <div class="px-6 py-6 space-y-4">
       {navLinks.map((link) => (
@@ -76,6 +76,7 @@ const navLinks = [
 
   function openMenu() {
     menu?.classList.replace('grid-rows-[0fr]', 'grid-rows-[1fr]');
+    menu?.removeAttribute('inert');
     menu?.setAttribute('aria-hidden', 'false');
     btn?.setAttribute('aria-expanded', 'true');
     icon?.setAttribute('d', 'M6 18L18 6M6 6l12 12');
@@ -83,6 +84,7 @@ const navLinks = [
 
   function closeMenu() {
     menu?.classList.replace('grid-rows-[1fr]', 'grid-rows-[0fr]');
+    menu?.setAttribute('inert', '');
     menu?.setAttribute('aria-hidden', 'true');
     btn?.setAttribute('aria-expanded', 'false');
     icon?.setAttribute('d', 'M4 6h16M4 12h16M4 18h16');

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -9,7 +9,7 @@ const navLinks = [
 
 <nav class="sticky top-0 z-50 bg-white border-b border-ui-border">
   <div class="max-w-site mx-auto px-6 md:px-12 py-4 flex items-center justify-between">
-    <a href="/" class="font-serif text-[22px] tracking-[-0.06em] text-forest hover:text-charcoal transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-forest focus-visible:ring-offset-1 rounded-sm">
+    <a href="/" class="font-serif text-[22px] tracking-[-0.06em] text-forest hover:text-charcoal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-forest focus-visible:ring-offset-1 rounded-sm" style="transition: color 150ms cubic-bezier(0.23, 1, 0.32, 1)">
       Lindahl Studios
     </a>
 
@@ -18,7 +18,7 @@ const navLinks = [
       {navLinks.map((link) => (
         <a
           href={link.href}
-          class="nav-link text-sm font-medium text-ui-muted hover:text-charcoal transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-forest focus-visible:ring-offset-1 rounded-sm"
+          class="nav-link text-sm font-medium text-ui-muted hover:text-charcoal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-forest focus-visible:ring-offset-1 rounded-sm"
         >
           {link.label}
         </a>
@@ -50,7 +50,7 @@ const navLinks = [
       {navLinks.map((link) => (
         <a
           href={link.href}
-          class="block text-base font-medium text-ui-body hover:text-charcoal transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-forest focus-visible:ring-offset-1 rounded-sm"
+          class="block text-base font-medium text-ui-body hover:text-charcoal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-forest focus-visible:ring-offset-1 rounded-sm" style="transition: color 150ms cubic-bezier(0.23, 1, 0.32, 1)"
         >
           {link.label}
         </a>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -44,9 +44,12 @@ const navLinks = [
     </button>
   </div>
 
-  <!-- Mobile menu — animated via grid-rows trick (no height: auto limitation) -->
+  <!-- Mobile menu — animated via grid-rows trick (no height: auto limitation).
+       Two-level structure is required: grid item must have min-h-0 and NO padding,
+       otherwise the padding prevents the track from collapsing to 0fr. -->
   <div id="mobile-menu" class="md:hidden border-t border-ui-border bg-white grid transition-[grid-template-rows] duration-[220ms] ease-[cubic-bezier(0.23,1,0.32,1)] grid-rows-[0fr] overflow-hidden" aria-hidden="true">
-    <div class="px-6 py-6 space-y-4 min-h-0">
+    <div class="min-h-0">
+    <div class="px-6 py-6 space-y-4">
       {navLinks.map((link) => (
         <a
           href={link.href}
@@ -62,6 +65,7 @@ const navLinks = [
         Let's Chat
       </a>
     </div>
+  </div>
   </div>
 </nav>
 

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -25,7 +25,7 @@ const navLinks = [
       ))}
       <a
         href="/contact"
-        class="px-6 py-3 bg-forest text-white rounded-lg text-sm font-semibold hover:bg-forest-light transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-forest focus-visible:ring-offset-2"
+        class="btn px-6 py-3 bg-forest text-white rounded-lg text-sm font-semibold hover:bg-forest-light focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-forest focus-visible:ring-offset-2"
       >
         Let's Chat
       </a>
@@ -57,7 +57,7 @@ const navLinks = [
       ))}
       <a
         href="/contact"
-        class="inline-block mt-2 px-6 py-3 bg-forest text-white rounded-lg text-sm font-semibold hover:bg-forest-light transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-forest focus-visible:ring-offset-2"
+        class="btn inline-block mt-2 px-6 py-3 bg-forest text-white rounded-lg text-sm font-semibold hover:bg-forest-light focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-forest focus-visible:ring-offset-2"
       >
         Let's Chat
       </a>

--- a/src/components/Work.astro
+++ b/src/components/Work.astro
@@ -143,7 +143,7 @@ const projects = [
                 )}
 
                 {/* Logo — fades out on desktop hover if screenshot exists */}
-                <div class={`absolute inset-0 flex items-center justify-center ${screenshotSrc ? 'group-hover:opacity-0' : ''}`} style={screenshotSrc ? 'transition: opacity 220ms cubic-bezier(0.23, 1, 0.32, 1)' : ''}>
+                <div class={`absolute inset-0 flex items-center justify-center ${screenshotSrc ? 'logo-fade group-hover:opacity-0' : ''}`}>
                   <img
                     src={localLogoSrc}
                     alt={`${project.client} logo`}
@@ -249,6 +249,14 @@ const projects = [
     :global(.group:hover) .work-screenshot {
       clip-path: inset(0 100% 0 0);
     }
+  }
+
+  /* Logo fade — opacity transition when screenshot wipes in on hover */
+  .logo-fade {
+    transition: opacity 220ms cubic-bezier(0.23, 1, 0.32, 1);
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .logo-fade { transition: none; }
   }
 </style>
 

--- a/src/components/Work.astro
+++ b/src/components/Work.astro
@@ -243,6 +243,13 @@ const projects = [
       z-index: 1;
     }
   }
+
+  /* Gate the clip-path wipe to pointer-capable devices only */
+  @media not (hover: hover) {
+    :global(.group:hover) .work-screenshot {
+      clip-path: inset(0 100% 0 0);
+    }
+  }
 </style>
 
 <script>

--- a/src/components/Work.astro
+++ b/src/components/Work.astro
@@ -143,7 +143,7 @@ const projects = [
                 )}
 
                 {/* Logo — fades out on desktop hover if screenshot exists */}
-                <div class={`absolute inset-0 flex items-center justify-center ${screenshotSrc ? 'transition-opacity duration-[220ms] group-hover:opacity-0' : ''}`}>
+                <div class={`absolute inset-0 flex items-center justify-center ${screenshotSrc ? 'group-hover:opacity-0' : ''}`} style={screenshotSrc ? 'transition: opacity 220ms cubic-bezier(0.23, 1, 0.32, 1)' : ''}>
                   <img
                     src={localLogoSrc}
                     alt={`${project.client} logo`}

--- a/src/pages/contact/index.astro
+++ b/src/pages/contact/index.astro
@@ -243,7 +243,7 @@ const description = 'Get in touch about your Shopify project. Custom development
             type="submit"
             class="group btn inline-block px-8 py-3.5 bg-forest text-white rounded-lg text-[15px] font-semibold hover:bg-forest-light focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-forest focus-visible:ring-offset-2"
           >
-            Send Message <span class="contact-arrow inline-block">→</span>
+            Send Message <span class="btn-arrow">→</span>
           </button>
         </form>
       </div>
@@ -252,16 +252,6 @@ const description = 'Get in touch about your Shopify project. Custom development
   <Footer />
 </BaseLayout>
 
-<style>
-  .contact-arrow {
-    transition: transform 200ms cubic-bezier(0.23, 1, 0.32, 1);
-  }
-  @media (hover: hover) and (pointer: fine) {
-    .group:hover .contact-arrow {
-      transform: translateX(4px);
-    }
-  }
-</style>
 
 <script>
   import Alpine from 'alpinejs';

--- a/src/pages/contact/index.astro
+++ b/src/pages/contact/index.astro
@@ -241,7 +241,7 @@ const description = 'Get in touch about your Shopify project. Custom development
 
           <button
             type="submit"
-            class="group inline-block px-8 py-3.5 bg-forest text-white rounded-lg text-[15px] font-semibold hover:bg-forest-light transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-forest focus-visible:ring-offset-2"
+            class="group btn inline-block px-8 py-3.5 bg-forest text-white rounded-lg text-[15px] font-semibold hover:bg-forest-light focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-forest focus-visible:ring-offset-2"
           >
             Send Message <span class="inline-block transition-transform duration-200 ease-out group-hover:translate-x-1">→</span>
           </button>

--- a/src/pages/contact/index.astro
+++ b/src/pages/contact/index.astro
@@ -243,7 +243,7 @@ const description = 'Get in touch about your Shopify project. Custom development
             type="submit"
             class="group btn inline-block px-8 py-3.5 bg-forest text-white rounded-lg text-[15px] font-semibold hover:bg-forest-light focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-forest focus-visible:ring-offset-2"
           >
-            Send Message <span class="inline-block transition-transform duration-200 ease-out group-hover:translate-x-1">→</span>
+            Send Message <span class="contact-arrow inline-block">→</span>
           </button>
         </form>
       </div>
@@ -251,6 +251,17 @@ const description = 'Get in touch about your Shopify project. Custom development
   </main>
   <Footer />
 </BaseLayout>
+
+<style>
+  .contact-arrow {
+    transition: transform 200ms cubic-bezier(0.23, 1, 0.32, 1);
+  }
+  @media (hover: hover) and (pointer: fine) {
+    .group:hover .contact-arrow {
+      transform: translateX(4px);
+    }
+  }
+</style>
 
 <script>
   import Alpine from 'alpinejs';

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -105,9 +105,7 @@ html body.sal-disabled [data-sal="fade-up"] {
     }
   }
 
-  /* CTA button — press feedback + precise transition (replaces transition-colors on CTAs).
-     Specifies only the properties that change so we avoid animating everything.
-     Active scale gives instant tactile confirmation on press. */
+  /* CTA button — press feedback + precise transition */
   .btn {
     transition:
       background-color 150ms cubic-bezier(0.23, 1, 0.32, 1),
@@ -133,8 +131,26 @@ html body.sal-disabled [data-sal="fade-up"] {
     animation: draw-check 0.45s cubic-bezier(0.25, 1, 0.5, 1) 0.15s forwards;
   }
 
+  /* Shared color transition — used on nav logo and mobile links */
+  .color-transition {
+    transition: color 150ms cubic-bezier(0.23, 1, 0.32, 1);
+  }
+
+  /* Arrow nudge on CTA hover — shared across Hero, FooterCTA, and contact page */
+  .btn-arrow {
+    display: inline-block;
+    transition: transform 200ms cubic-bezier(0.23, 1, 0.32, 1);
+  }
+  @media (hover: hover) and (pointer: fine) {
+    .group:hover .btn-arrow {
+      transform: translateX(4px);
+    }
+  }
+
   @media (prefers-reduced-motion: reduce) {
     .nav-link::after { transition: none; }
     .check-draw { animation: none; stroke-dashoffset: 0; }
+    .color-transition { transition: none; }
+    .btn-arrow { transition: none; }
   }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -102,6 +102,24 @@ html body.sal-disabled [data-sal="fade-up"] {
     transform: scaleX(1);
   }
 
+  /* CTA button — press feedback + precise transition (replaces transition-colors on CTAs).
+     Specifies only the properties that change so we avoid animating everything.
+     Active scale gives instant tactile confirmation on press. */
+  .btn {
+    transition:
+      background-color 150ms cubic-bezier(0.23, 1, 0.32, 1),
+      border-color     150ms cubic-bezier(0.23, 1, 0.32, 1),
+      color            150ms cubic-bezier(0.23, 1, 0.32, 1),
+      transform        100ms cubic-bezier(0.23, 1, 0.32, 1);
+  }
+  .btn:active {
+    transform: scale(0.97);
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .btn { transition: none; }
+    .btn:active { transform: none; }
+  }
+
   /* Checkmark draw animation for contact success */
   @keyframes draw-check {
     to { stroke-dashoffset: 0; }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -82,9 +82,10 @@ html body.sal-disabled [data-sal="fade-up"] {
 /* ── end sal.js overrides ─────────────────────────────────────────────────── */
 
 @layer utilities {
-  /* Nav link underline — draws left to right on hover */
+  /* Nav link — color + underline draw on hover */
   .nav-link {
     position: relative;
+    transition: color 150ms cubic-bezier(0.23, 1, 0.32, 1);
   }
   .nav-link::after {
     content: '';
@@ -98,8 +99,10 @@ html body.sal-disabled [data-sal="fade-up"] {
     transform-origin: left;
     transition: transform 0.25s cubic-bezier(0.25, 1, 0.5, 1);
   }
-  .nav-link:hover::after {
-    transform: scaleX(1);
+  @media (hover: hover) and (pointer: fine) {
+    .nav-link:hover::after {
+      transform: scaleX(1);
+    }
   }
 
   /* CTA button — press feedback + precise transition (replaces transition-colors on CTAs).


### PR DESCRIPTION
## Summary

Applied Emil Kowalski's animation framework to audit and improve every animated element on the site.

- **Button press feedback** — Added `.btn` utility with `scale(0.97)` on `:active` + precise multi-property transition (ease-out curve) to all CTA buttons. Every pressable element now acknowledges a press.
- **Mobile menu transition** — Replaced instant `classList.toggle('hidden')` with a 220ms `grid-rows-[0fr→1fr]` slide using ease-out-expo.
- **Nav easing** — Replaced Tailwind's default `cubic-bezier(0.4, 0, 0.2, 1)` (ease-in-out) with `cubic-bezier(0.23, 1, 0.32, 1)` on all nav color/underline transitions.
- **Hover guards** — CTA arrow nudge, work screenshot wipe, and logo fade all gated behind `@media (hover: hover) and (pointer: fine)` so they don't fire on touch tap.
- **Footer wordmark blur** — Reduced from `blur(20px)/1.4s` → `blur(12px)/0.9s` (Safari perf + timing).
- **Booking badge pulse** — Removed infinite `animate-pulse` loop; static dot, copy does the work.
- **Hero word-reveal** — Duration `780ms → 600ms` per word, same energy, snappier feel.
- **Hero CTA delay** — sal-delay on CTA buttons `400ms → 280ms` so users don't wait to interact.
- **Work logo easing** — Explicit `cubic-bezier(0.23, 1, 0.32, 1)` instead of Tailwind default on opacity exit.

## Test plan

- [x] Click every CTA button — should feel a subtle scale-down on press
- [x] Open/close mobile menu — should slide smoothly, no instant jump
- [x] Hover nav links on desktop — underline draws, color shifts instantly responsive
- [x] Tap nav links on mobile — no arrow nudge or unwanted hover effects fire
- [x] Scroll to footer on desktop — wordmark reveals more quickly, blur is lighter
- [x] Load hero — word reveal feels tighter, buttons appear sooner
- [x] Verify `prefers-reduced-motion` — `.btn` has `transition: none` fallback