### PR TITLE
feat: quote callout section + homepage section reorder (issue #34)

### DIFF
--- a/src/components/Availability.astro
+++ b/src/components/Availability.astro
@@ -11,7 +11,7 @@
     >
       <p class="text-[11px] font-semibold text-forest tracking-[0.12em] uppercase mb-3">How I work</p>
       <h2 class="font-serif text-[30px] md:text-[52px] leading-[1.08]">
-        A few honest things.
+        A few honest things
       </h2>
     </div>
 
@@ -29,7 +29,7 @@
             <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
           </svg>
         </div>
-        <h3 class="font-serif text-xl mb-4">What working with me looks like</h3>
+        <h3 class="font-serif text-xl mb-4">What working with me looks like:</h3>
         <ul class="space-y-3 text-[15px] leading-[1.7] text-ui-body">
           <li class="flex items-start gap-3">
             <span class="text-forest mt-1 flex-shrink-0">

--- a/src/components/QuoteCallout.astro
+++ b/src/components/QuoteCallout.astro
@@ -14,7 +14,6 @@ const title = 'Marketing Manager, Sunday Golf';
       data-sal="fade-up"
       data-sal-duration="500"
     >
-      <!-- Decorative opening quote mark -->
       <div
         class="font-serif leading-none text-forest/20 mb-4 select-none text-[80px] md:text-[120px]"
         aria-hidden="true"

--- a/src/components/QuoteCallout.astro
+++ b/src/components/QuoteCallout.astro
@@ -6,7 +6,7 @@ const name = 'Raf';
 const title = 'Marketing Manager, Sunday Golf';
 ---
 
-<section class="bg-cream">
+<section class="bg-white">
   <div class="max-w-site mx-auto px-6 md:px-12 py-20 md:py-28">
 
     <div

--- a/src/components/QuoteCallout.astro
+++ b/src/components/QuoteCallout.astro
@@ -1,0 +1,44 @@
+---
+const quote =
+  "What stood out most was his expertise — and he took the time to research and suggest strategies that would benefit us in the long run. Working with David felt like he was part of our team, and not just rushing to get the job done.";
+
+const name = 'Raf';
+const title = 'Marketing Manager, Sunday Golf';
+---
+
+<section class="bg-cream">
+  <div class="max-w-site mx-auto px-6 md:px-12 py-20 md:py-28">
+
+    <div
+      class="max-w-[800px]"
+      data-sal="fade-up"
+      data-sal-duration="500"
+    >
+      <!-- Decorative opening quote mark -->
+      <div
+        class="font-serif leading-none text-forest/20 mb-4 select-none text-[80px] md:text-[120px]"
+        aria-hidden="true"
+      >&ldquo;</div>
+
+      <blockquote
+        class="font-serif text-[22px] md:text-[34px] leading-[1.45] tracking-[-0.02em] text-charcoal mb-8"
+      >
+        {quote}
+      </blockquote>
+
+      <div class="flex flex-col sm:flex-row sm:items-center gap-4 sm:gap-8">
+        <cite class="text-sm not-italic text-ui-muted">
+          <strong class="text-charcoal font-semibold">{name}</strong>,{' '}{title}
+        </cite>
+
+        <a
+          href="#testimonials"
+          class="group color-transition inline-flex items-center gap-1.5 text-sm font-medium text-forest hover:text-charcoal flex-shrink-0"
+        >
+          Read more reviews <span class="btn-arrow">→</span>
+        </a>
+      </div>
+    </div>
+
+  </div>
+</section>

--- a/src/components/Testimonials.astro
+++ b/src/components/Testimonials.astro
@@ -59,19 +59,21 @@ const secondary = [
       data-sal="fade-up"
       data-sal-duration="500"
     >
-      <!-- Decorative opening quote mark — typographic accent, not read aloud -->
-      <div
-        class="font-serif text-[40px] md:text-[72px] leading-none text-forest/30 mb-2 select-none"
-        aria-hidden="true"
-      >&ldquo;</div>
+      <div class="max-w-[800px]">
+        <!-- Decorative opening quote mark — typographic accent, not read aloud -->
+        <div
+          class="font-serif text-[40px] md:text-[72px] leading-none text-forest/30 mb-4 select-none"
+          aria-hidden="true"
+        >&ldquo;</div>
 
-      <blockquote class="font-serif text-[20px] md:text-[26px] leading-[1.65] text-charcoal mb-6 max-w-[660px]">
-        {featured.quote}
-      </blockquote>
+        <blockquote class="font-serif text-[20px] md:text-[26px] leading-[1.65] tracking-[-0.02em] text-charcoal mb-6">
+          {featured.quote}
+        </blockquote>
 
-      <cite class="text-sm not-italic text-ui-muted">
-        <strong class="text-charcoal font-semibold">{featured.name}</strong>,{' '}{featured.title}
-      </cite>
+        <cite class="text-sm not-italic text-ui-muted">
+          <strong class="text-charcoal font-semibold">{featured.name}</strong>,{' '}{featured.title}
+        </cite>
+      </div>
     </div>
 
     <!-- Secondary testimonials -->

--- a/src/components/Testimonials.astro
+++ b/src/components/Testimonials.astro
@@ -27,7 +27,7 @@ const secondary = [
   },
   {
     quote:
-      "David demonstrated a deep understanding of our requirements and goals. His ability to anticipate potential challenges and proactively address them exceeded our expectations.",
+      "One of the most impressive aspects of David's work was his ability to anticipate potential challenges and proactively address them. Working with David was a delight — his professionalism and dedication to high-quality results make him an invaluable asset to any project.",
     name: 'Chris Lang',
     title: 'Fresh Chile',
   },

--- a/src/components/Testimonials.astro
+++ b/src/components/Testimonials.astro
@@ -1,7 +1,7 @@
 ---
 const featured = {
   quote:
-    'Really enjoyed working with David to implement recommendations from an Oddit report to enhance our UX and site functionality. David set up a project timeline via Basecamp which made the workflow move really efficiently. His communication and updates were timely and organized. Not only did he have the technical chops to make the developer changes required, David also suggested and implemented his own UX improvements. We\'ll definitely look to partner with David again in the future to assist us with development work that falls outside of our scope and skill set.',
+    'Really enjoyed working with David to implement recommendations from an Oddit report to enhance our UX and site functionality. David set up a project timeline via Basecamp which made the workflow move really efficiently. His communication and updates were timely and organized. Not only did he have the technical chops to make the developer changes required, David also suggested and implemented his own UX improvements.',
   name: 'Curtis Ulrich',
   title: 'Director of eCommerce, Aviator Nation',
 };

--- a/src/components/Testimonials.astro
+++ b/src/components/Testimonials.astro
@@ -9,27 +9,27 @@ const featured = {
 const secondary = [
   {
     quote:
-      "I really enjoyed working with David. I came to him with basically a couple screenshots and an idea in my head and he turned it into working Liquid in about 4 days flat. He's a great communicator and a pleasure to work with.",
-    name: 'Kaine Kornegay',
-    title: 'Co-Founder, Revolution Fibers',
-  },
-  {
-    quote:
       "I'm really impressed with the work David did for us. He was incredibly detailed and communicative throughout the entire time we worked with him. What stood out most was his expertise — and he took the time to research and suggest strategies that would benefit us in the long run.",
     name: 'Raf',
     title: 'Marketing Manager, Sunday Golf',
   },
   {
     quote:
-      "Working with David was an enjoyable and collaborative experience and the product he delivered met all of my expectations. To this day I continue to partner with David on projects. I 10/10 would recommend!",
-    name: 'Amanda P',
-    title: 'Art Director, good culture',
-  },
-  {
-    quote:
       "One of the most impressive aspects of David's work was his ability to anticipate potential challenges and proactively address them. Working with David was a delight — his professionalism and dedication to high-quality results make him an invaluable asset to any project.",
     name: 'Chris Lang',
     title: 'Fresh Chile',
+  },
+  {
+    quote:
+      "I really enjoyed working with David. I came to him with basically a couple screenshots and an idea in my head and he turned it into working Liquid in about 4 days flat. He's a great communicator and a pleasure to work with.",
+    name: 'Kaine Kornegay',
+    title: 'Co-Founder, Revolution Fibers',
+  },
+  {
+    quote:
+      "Working with David was an enjoyable and collaborative experience and the product he delivered met all of my expectations. To this day I continue to partner with David on projects. I 10/10 would recommend!",
+    name: 'Amanda P',
+    title: 'Art Director, good culture',
   },
 ];
 ---

--- a/src/components/Testimonials.astro
+++ b/src/components/Testimonials.astro
@@ -1,7 +1,7 @@
 ---
 const featured = {
   quote:
-    'Not only did he have the technical chops to make the developer changes required, David also suggested and implemented his own UX improvements. We\'ll definitely look to partner with David again in the future.',
+    'Really enjoyed working with David to implement recommendations from an Oddit report to enhance our UX and site functionality. David set up a project timeline via Basecamp which made the workflow move really efficiently. His communication and updates were timely and organized. Not only did he have the technical chops to make the developer changes required, David also suggested and implemented his own UX improvements. We\'ll definitely look to partner with David again in the future to assist us with development work that falls outside of our scope and skill set.',
   name: 'Curtis Ulrich',
   title: 'Director of eCommerce, Aviator Nation',
 };

--- a/src/components/ValueProp.astro
+++ b/src/components/ValueProp.astro
@@ -2,7 +2,7 @@
 
 ---
 
-<section class="bg-white border-y border-forest/[0.12]">
+<section class="bg-white">
   <div class="max-w-site mx-auto px-6 md:px-12 py-24 md:py-36">
     <p
       class="font-serif leading-[1.18] tracking-[-0.03em] text-charcoal"

--- a/src/components/Work.astro
+++ b/src/components/Work.astro
@@ -93,7 +93,7 @@ const projects = [
       data-sal="fade-up"
       data-sal-duration="500"
     >
-      Selected Work
+      Work
     </p>
     <h2
       class="font-serif text-[30px] md:text-[52px] leading-[1.1] mb-10"
@@ -101,7 +101,7 @@ const projects = [
       data-sal-duration="500"
       data-sal-delay="80"
     >
-      Work
+      Selected Projects
     </h2>
 
     <!-- Editorial project list — full-width rows with hairline separators -->

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,9 +25,9 @@ import '../styles/global.css';
     <QuoteCallout />
     <Work />
     <Services />
+    <FewerClients />
     <ValueProp />
     <ProcessTimeline />
-    <FewerClients />
     <Availability />
     <About />
     <Testimonials />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,10 +22,10 @@ import '../styles/global.css';
   <main id="content">
     <Hero />
     <ClientLogos />
-    <ValueProp />
-    <Services />
     <QuoteCallout />
     <Work />
+    <Services />
+    <ValueProp />
     <ProcessTimeline />
     <FewerClients />
     <Availability />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -26,8 +26,8 @@ import '../styles/global.css';
     <Work />
     <Services />
     <FewerClients />
-    <ValueProp />
     <ProcessTimeline />
+    <ValueProp />
     <Availability />
     <About />
     <Testimonials />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,6 +5,7 @@ import Hero from '../components/Hero.astro';
 import ClientLogos from '../components/ClientLogos.astro';
 import ValueProp from '../components/ValueProp.astro';
 import Services from '../components/Services.astro';
+import QuoteCallout from '../components/QuoteCallout.astro';
 import Work from '../components/Work.astro';
 import ProcessTimeline from '../components/ProcessTimeline.astro';
 import FewerClients from '../components/FewerClients.astro';
@@ -23,6 +24,7 @@ import '../styles/global.css';
     <ClientLogos />
     <ValueProp />
     <Services />
+    <QuoteCallout />
     <Work />
     <ProcessTimeline />
     <FewerClients />


### PR DESCRIPTION
Closes #34

## Summary

- **New `QuoteCallout` component** — prominent pull-quote between ClientLogos and Work featuring Raf / Sunday Golf: *"Working with David felt like he was part of our team, and not just rushing to get the job done."* White background to contrast the cream hero, jumps to `#testimonials` on click
- **Homepage section reorder** — new flow optimised for a skeptical operator: Hero → ClientLogos → QuoteCallout → Work → Services → FewerClients → ProcessTimeline → ValueProp → Availability → About → Testimonials → FooterCTA
- **Testimonials featured card** — updated to full Curtis Ulrich quote (trimmed the forward-looking sentence); composition fixed with a shared `max-w-[800px]` wrapper so the quote mark, blockquote, and attribution align as one column
- **Copy fixes** — removed period from "A few honest things", added colon before bullet list, fixed "Selected Work / Work" repetition in the Work section (now "Work / Selected Projects")
- **Border consistency** — removed `border-y` from ValueProp so all white sections are border-free

## Test plan

- [x] QuoteCallout renders correctly on mobile and desktop
- [x] "Read more reviews →" link scrolls to `#testimonials`
- [x] Arrow nudge animates on hover (pointer devices only)
- [x] Section order matches: Hero → ClientLogos → QuoteCallout → Work → Services → FewerClients → ProcessTimeline → ValueProp → Availability → About → Testimonials → FooterCTA
- [x] Testimonials featured card text and quote mark sit within the `max-w-[800px]` column — no awkward right-side gap
- [x] No white/cream border visible between any two white sections
- [x] Copy: heading reads "A few honest things" (no period), "What working with me looks like:" (colon), Work eyebrow "Work" + h2 "Selected Projects"